### PR TITLE
allow select queries to begin "select\n"

### DIFF
--- a/base/data_store/provider.py
+++ b/base/data_store/provider.py
@@ -508,7 +508,7 @@ class DataStoreMySQL(RDBMSBase):
         self.connect()
 
         is_select = False
-        if re.match('^\(?select ', sql, re.IGNORECASE) or \
+        if re.match('^\(?select\s', sql, re.IGNORECASE) or \
            re.match('^show ', sql, re.IGNORECASE):
             is_select = True
 


### PR DESCRIPTION
`DataStoreMySQL.query()` determines its return type based on the beginning of the query string. 
This fixes a bug where a query formatted like: 

```
select
    field1, field2
from 
    some_table
``` 

would not be parsed as a `select` query.