### PR TITLE
Don't specify collation/charset for binary/varbinary data types

### DIFF
--- a/base/services/table_builder/mysql.py
+++ b/base/services/table_builder/mysql.py
@@ -358,7 +358,9 @@ class _MySQLStringColumn(__MySQLColumn):
         if self.__type_id not in [self.TYPE_TINYBLOB,
                                   self.TYPE_BLOB,
                                   self.TYPE_MEDIUMBLOB,
-                                  self.TYPE_LONGBLOB]:
+                                  self.TYPE_LONGBLOB,
+                                  self.TYPE_VARBINARY,
+                                  self.TYPE_BINARY]:
             if self.__charset is not None:
                 terms.append('character set ' + self.__charset)
 

--- a/base/services/table_builder/tests/mysql_tests.py
+++ b/base/services/table_builder/tests/mysql_tests.py
@@ -572,7 +572,7 @@ class TableBuilderMySQLTestCase(unittest.TestCase):
 
     def test_string_binary_binary(self):
         self.assertEqual(
-            "abc binary(15) character set def collate ghi default null",
+            "abc binary(15) default null",
             _MySQLStringColumn('abc')
                 .binary_type(_MySQLStringColumn.TYPE_BINARY, 15)
                 .charset('def')
@@ -582,7 +582,7 @@ class TableBuilderMySQLTestCase(unittest.TestCase):
 
     def test_string_binary_varbinary(self):
         self.assertEqual(
-            "abc varbinary(15) character set def collate ghi default null",
+            "abc varbinary(15) default null",
             _MySQLStringColumn('abc')
                 .binary_type(_MySQLStringColumn.TYPE_VARBINARY, 15)
                 .charset('def')
@@ -675,8 +675,8 @@ class TableBuilderMySQLTestCase(unittest.TestCase):
 (
     def char(15) character set utf8 collate utf8_unicode_ci not null,
     ghi varchar(16) character set utf8 collate utf8_unicode_ci not null,
-    jkl binary(17) character set utf8 collate utf8_unicode_ci not null,
-    mno varbinary(18) character set utf8 collate utf8_unicode_ci not null,
+    jkl binary(17) not null,
+    mno varbinary(18) not null,
     pqr tinyblob not null,
     stu blob(19) not null,
     vwx mediumblob not null,


### PR DESCRIPTION
Fixes mysql error when using tinyAPI.Table.vbin(...) and tinyAPI.Table.bin(...)

For this table definition:
```
tinyAPI.Table('some_table')\
    .vbin('test', 100, False)\
    .bin('test2', 100, False)
```

Outputs sql:
```
create table vbintest_test
(
    test varbinary(100) default null,
    test2 binary(100) default null
) engine = innodb default charset = utf8 collate = utf8_unicode_ci;
```

Previously it output this: 
```
create table vbintest_test
(
    test varbinary(100) character set utf8 collate utf8_unicode_ci default null,
    test2 binary(100) character set utf8 collate utf8_unicode_ci default null
) engine = innodb default charset = utf8 collate = utf8_unicode_ci;
```

Which would trigger the below error because varbinary and binary don't take the `character set` and `collate` options
```
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'character set utf8 collate utf8_unicode_ci default null' at line 3
```

