### PR TITLE
DatastoreMySQL.delete() can be called with more than one delete parameter

### DIFF
--- a/base/data_store/provider.py
+++ b/base/data_store/provider.py
@@ -397,7 +397,7 @@ class DataStoreMySQL(RDBMSBase):
 
         binds = None
         if len(data) > 0:
-            sql += ' where ' + self.__convert_to_prepared(', ', data)
+            sql += ' where ' + self.__convert_to_prepared(' and ', data)
             binds = list(data.values())
 
         self.connect()

--- a/base/data_store/tests/provider_mysql_tests.py
+++ b/base/data_store/tests/provider_mysql_tests.py
@@ -89,6 +89,38 @@ class ProviderMySQLTestCase(unittest.TestCase):
                 4,
                 tinyAPI.dsh().count('select count(*) from unit_test_table'))
 
+    def test_deleting_from_table_multi_field(self):
+        if self.__execute_tests is True:
+            tinyAPI.dsh().create(
+                'unit_test_table',
+                {'value': 1,
+                 'ti': '10:00:00'}
+            )
+            tinyAPI.dsh().create(
+                'unit_test_table',
+                {'value': 1,
+                 'ti': '11:00:00'}
+            )
+            tinyAPI.dsh().create(
+                'unit_test_table',
+                {'value': 1,
+                 'ti': '12:00:00'}
+            )
+
+            self.assertEqual(
+                3,
+                tinyAPI.dsh().count('select count(*) from unit_test_table')
+            )
+
+            tinyAPI.dsh().delete(
+                'unit_test_table',
+                {'value': 1, 'ti': '10:00:00'}
+            )
+            self.assertEqual(
+                2,
+                tinyAPI.dsh().count('select count(*) from unit_test_table')
+            )
+
 
     def test_asserting_is_dsh_errors(self):
         try:


### PR DESCRIPTION
Currently, the following usage of DatastoreMySQL.delete() fails with a sql syntax error. 
```
dsh = DatastoreMySQL()
dsh.select_db(...)
dsh.delete(
    'some_table',
    {'field1': 'value', 'field2': 'other_value'}
)

pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' field2 = 'other_value'' at line 1")
```

This change would allow you to delete using multiple criteria. Key value pairs are AND'd together. 

With this change, the above issues this query: 

```
delete 
from some_table
where field1 = 'value'
  and field2 = 'other_value'
```

Fixes #6 