### PR TITLE
Enables "LOAD DATA LOCAL INFILE"

### DIFF
--- a/base/data_store/provider.py
+++ b/base/data_store/provider.py
@@ -300,6 +300,7 @@ class DataStoreMySQL(RDBMSBase):
             'host': connection_data[self._connection_name][0],
             'database': self._db_name,
             'charset': self._charset,
+            'local_infile': True,
             'autocommit': False
         }
 


### PR DESCRIPTION
This is the correct fix. No harm done in including it in the previous change.
https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/connections.py#L159
